### PR TITLE
Fix `GUSINFO` separator in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 #ECCN:Open Source
-#GUSINFO:Heroku Product	Public Roadmap
+#GUSINFO:Heroku Product,Public Roadmap
 * heroku/product


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` separates the team and product tag with a tab rather than a comma, so it does not parse. Both names are already correct, so this change only replaces the separator.

GUS-W-23525396.